### PR TITLE
Date is not a mandatory header

### DIFF
--- a/signature.go
+++ b/signature.go
@@ -132,10 +132,6 @@ func (s *Signature) sign(key string, r *http.Request) error {
 
 // IsValid validates this signature for the given key
 func (s Signature) IsValid(key string, r *http.Request) bool {
-	if !s.Headers.hasDate() {
-		return false
-	}
-
 	sig, err := s.calculateSignature(key, r)
 	if err != nil {
 		return false


### PR DESCRIPTION
According to IETF specs `Date` is suggested but not mandatory:

> 2.3.  Signature String Construction
> 
>    In order to generate the string that is signed with a key, the client
>    MUST use the values of each HTTP header field in the `headers`
>    Signature parameter, in the order they appear in the `headers`
>    Signature parameter.  It is out of scope for this document to dictate
>    what header fields an application will want to enforce, but
>    implementers SHOULD at minimum include the request target and Date
>    header fields.

https://tools.ietf.org/html/draft-cavage-http-signatures